### PR TITLE
Added GitHub actions workflow for PyPi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  release-pypi:
+    name: release-pypi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Upgrade pip
+        run: pip install pip --upgrade
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install .
+      - name: Build for distribution
+        run: python setup.py sdist bdist_wheel
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: "${{ secrets.PYPI_API_TOKEN }}"
+      - name: Create Release
+        uses: actions/create-release@main
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          tag_name: "${{ github.ref }}"
+          release_name: "v${{ github.ref }}"
+          draft: true
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 - [Sponsors](#sponsors)
 - [About](#about)
 - [Installation](#installation)
-  - [Requirements](#requirements)
 - [Data pipeline](#data-pipeline)
 - [What's available](#whats-available)
   - [Audio feature extraction](#audio-feature-extraction)
@@ -27,20 +26,16 @@ Expect changes, restructuring, and like the official Jax repository itself says,
 
 ## Installation
 
-### Requirements
-```
-jax
-flax>=0.4.0
-optax==0.1.1
-tensorflow>=2.7.0
-tensorflow-datasets
-tensorflow-io   # for audio decoding
+```shell
+pip install audax
 ```
 
-After installing prerequisites, to install audax
+To install from the latest source use following command
+
 ```shell
 git clone https://github.com/SarthakYadav/audax.git
 cd audax
+pip install -r requirements.txt
 pip install .
 ```
 
@@ -91,7 +86,6 @@ Sample recipes, as well as pretrained models ([AudioSet](https://research.google
 - Recipes for Speaker Recognition on [VoxCeleb](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/)
 - More `AudioSet` pretrained checkpoints for architectures already added.
 - Reference implementations for more neural architectures, esp. Transformer based networks.
-- PyPi release (soon!)
 
 ## On contributing
 - At the time of writing, I've been the sole person involved in development of this work, and quite frankly, would love to have help!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+jax
+flax>=0.4.0
+optax==0.1.1
+tensorflow>=2.7.0
+tensorflow-datasets
+tensorflow-io


### PR DESCRIPTION
This PR adds auto build and release of package to PyPi using [GitHub actions](https://github.com/features/actions).

This workflow will be triggered when new [tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) are pushed to the repository, it will publish the package to PyPi and also create a [release](https://docs.github.com/en/repositories/releasing-projects-on-github/viewing-your-repositorys-releases-and-tags#viewing-tags) in the draft state on GitHub which later can be published.

Note: To get it working it is required to [set](https://stackoverflow.com/a/57706400/3190234) the secret `PYPI_API_TOKEN` in this repository. To generate `PYPI_API_TOKEN` check [here](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).
